### PR TITLE
Accept all 2xx response code as OK

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -123,7 +123,7 @@ func doReg(client *http.Client, config *Config, url, resource string, update boo
 		return err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
+	if res.StatusCode < 200 || res.StatusCode > 299 {
 		return responseError(res)
 	}
 


### PR DESCRIPTION
Letsencrypt staging responds with 202 Accepted on GetReg.
Plus, 2xx is always a good response anyway.

R: @sgomes, @surma