### PR TITLE
Predefined ACME error types

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -476,38 +476,3 @@ func retryAfter(v string) time.Duration {
 func keyAuth(pub *rsa.PublicKey, token string) string {
 	return fmt.Sprintf("%s.%s", token, JWKThumbprint(pub))
 }
-
-// Error is an ACME error.
-type Error struct {
-	Code   int
-	Type   string
-	Detail string
-}
-
-func (e *Error) Error() string {
-	if e.Detail == "" {
-		return e.Type
-	}
-	return e.Detail
-}
-
-func responseError(resp *http.Response) error {
-	b, _ := ioutil.ReadAll(resp.Body)
-	e := &Error{Code: resp.StatusCode}
-	if err := json.Unmarshal(b, e); err == nil {
-		return e
-	}
-	e.Detail = string(b)
-	if e.Detail == "" {
-		e.Detail = resp.Status
-	}
-	return e
-}
-
-// RetryError is a "temporary" error indicating that the request
-// can be retried after the specified duration.
-type RetryError time.Duration
-
-func (re RetryError) Error() string {
-	return fmt.Sprintf("retry after %s", re)
-}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goacme
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// ErrorType is used to define a set of errors predefined by the ACME spec.
+type ErrorType string
+
+const (
+	ErrBadCSR       = "urn:acme:error:badCSR"         // The CSR is unacceptable (e.g., due to a short key)
+	ErrBadNonce     = "urn:acme:error:badNonce"       // The client sent an unacceptable anti-replay nonce
+	ErrConnection   = "urn:acme:error:connection"     // The server could not connect to the client for DV
+	ErrDNSSec       = "urn:acme:error:dnssec"         // The server could not validate a DNSSEC signed domain
+	ErrMalformed    = "urn:acme:error:malformed"      // The request message was malformed
+	ErrInternal     = "urn:acme:error:serverInternal" // The server experienced an internal error
+	ErrTLS          = "urn:acme:error:tls"            // The server experienced a TLS error during DV
+	ErrUnauthorized = "urn:acme:error:unauthorized"   // The client lacks sufficient authorization
+	ErrUnknownHost  = "urn:acme:error:unknownHost"    // The server could not resolve a domain name
+	ErrRateLimited  = "urn:acme:error:rateLimited"    // The request exceeds a rate limit
+)
+
+// Error is an ACME error.
+type Error struct {
+	Code   int `json:"status"`
+	Type   ErrorType
+	Detail string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%d %s: %s", e.Code, e.Type, e.Detail)
+}
+
+// responseError creates an error of Error type from resp.
+func responseError(resp *http.Response) error {
+	b, _ := ioutil.ReadAll(resp.Body)
+	e := &Error{Code: resp.StatusCode}
+	if err := json.Unmarshal(b, e); err == nil {
+		return e
+	}
+	e.Detail = string(b)
+	if e.Detail == "" {
+		e.Detail = resp.Status
+	}
+	return e
+}
+
+// RetryError is a "temporary" error indicating that the request
+// can be retried after the specified duration.
+type RetryError time.Duration
+
+func (re RetryError) Error() string {
+	return fmt.Sprintf("retry after %s", re)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goacme
+
+import (
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResponseError(t *testing.T) {
+	err500 := &Error{Code: 500, Detail: "500 Internal"}
+	errTLS := &Error{Code: 500, Type: ErrTLS, Detail: "TLS err"}
+	errCSR := &Error{Code: 400, Type: ErrBadCSR, Detail: "bad CSR"}
+	tests := []struct {
+		body   string
+		status string
+		code   int
+		err    *Error
+	}{
+		{"", "500 Internal", 500, err500},
+		{`{"type":"urn:acme:error:tls","detail":"TLS err"}`, "500 Server Error", 500, errTLS},
+		{`{"type":"urn:acme:error:badCSR","detail":"bad CSR","status":400}`, "500 Server Error", 500, errCSR},
+	}
+	for i, test := range tests {
+		res := &http.Response{
+			Body:       ioutil.NopCloser(strings.NewReader(test.body)),
+			Status:     test.status,
+			StatusCode: test.code,
+		}
+		err := responseError(res)
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("%d: responseError: %+v; want %+v", i, err, test.err)
+		}
+	}
+}


### PR DESCRIPTION
A possible solution for #15.

Example usage:

    err := client.Register(url, a)
    if err, ok := err.(*Error); ok && err.Type == ErrBadCSR {
      // handle urn:acme:error:badCSR error
    }

@mbwalas WDYT?