### PR TITLE
Fix golint using type in variable declaration

### DIFF
--- a/cmd/goacme/main_test.go
+++ b/cmd/goacme/main_test.go
@@ -22,15 +22,15 @@ func TestDiscoAliasFlag(t *testing.T) {
 		{defaultDisco, []string{"-d", "https://disco"}, "https://disco"},
 	}
 	for i, test := range tests {
-		var a discoAliasFlag = test.a
+		var daf = test.a
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
-		fs.Var(&a, "d", "")
+		fs.Var(&daf, "d", "")
 		if err := fs.Parse(test.args); err != nil {
 			t.Errorf("%d: parse(%v): %v", i, test.args, err)
 			continue
 		}
-		if a.String() != test.want {
-			t.Errorf("%d: a = %q; want %q", i, a, test.want)
+		if daf.String() != test.want {
+			t.Errorf("%d: a = %q; want %q", i, daf, test.want)
 		}
 	}
 }

--- a/cmd/goacme/main_test.go
+++ b/cmd/goacme/main_test.go
@@ -22,15 +22,15 @@ func TestDiscoAliasFlag(t *testing.T) {
 		{defaultDisco, []string{"-d", "https://disco"}, "https://disco"},
 	}
 	for i, test := range tests {
-		var daf = test.a
+		var a = test.a
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
-		fs.Var(&daf, "d", "")
+		fs.Var(&a, "d", "")
 		if err := fs.Parse(test.args); err != nil {
 			t.Errorf("%d: parse(%v): %v", i, test.args, err)
 			continue
 		}
-		if daf.String() != test.want {
-			t.Errorf("%d: a = %q; want %q", i, daf, test.want)
+		if a.String() != test.want {
+			t.Errorf("%d: a = %q; want %q", i, a, test.want)
 		}
 	}
 }


### PR DESCRIPTION
This fixes:

    main_test.go:25:9: should omit type discoAliasFlag from declaration of var a; it will be inferred from the right-hand side